### PR TITLE
upgrade bento/ubuntu vagrant box version to 22.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
       echo "$IP_NW$((IP_START+2)) worker-node02" >> /etc/hosts
   SHELL
 
-  config.vm.box = "bento/ubuntu-21.10"
+  config.vm.box = "bento/ubuntu-22.04"
   config.vm.box_check_update = true
 
   config.vm.define "master" do |master|


### PR DESCRIPTION
#18 #16
update to newer Vagrant box: [bento/ubuntu-22.04](https://app.vagrantup.com/bento/boxes/ubuntu-22.04) for long-term Ubuntu standard support until April 2027.