### PR TITLE
Update Kubernetes version to 1.25

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 # Variable Declaration
 
-KUBERNETES_VERSION="1.23.6-00"
+KUBERNETES_VERSION="1.25.5-00"
 
 # disable swap
 sudo swapoff -a
@@ -18,7 +18,7 @@ sudo apt-get update -y
 
 OS="xUbuntu_20.04"
 
-VERSION="1.23"
+VERSION="1.25"
 
 # Create the .conf file to load the modules at bootup
 cat <<EOF | sudo tee /etc/modules-load.d/crio.conf

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -8,6 +8,15 @@ set -euxo pipefail
 
 KUBERNETES_VERSION="1.25.5-00"
 
+# DNS Setting
+sudo mkdir /etc/systemd/resolved.conf.d/
+cat <<EOF | sudo tee /etc/systemd/resolved.conf.d/dns_servers.conf
+[Resolve]
+DNS=8.8.8.8 1.1.1.1
+EOF
+
+sudo systemctl restart systemd-resolved
+
 # disable swap
 sudo swapoff -a
 

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -61,6 +61,17 @@ metadata:
 EOF
 
 cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: admin-user
+EOF
+
+cat <<EOF | kubectl apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
CKAD and CKS are based on Kubernetes v1.25 now.

Plus, There is big change in K8s 1.24 about ServiceAccounts and their Secrets.
K8s won’t generate Secrets any longer automatically for ServiceAccounts. So, We need to create manually.