### PR TITLE
The IP address is not within the allowed ranges

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 NUM_WORKER_NODES=2
-IP_NW="10.0.0."
+IP_NW="192.168.56."
 IP_START=10
 
 Vagrant.configure("2") do |config|

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-MASTER_IP="10.0.0.10"
+MASTER_IP="192.168.56.10"
 NODENAME=$(hostname -s)
 POD_CIDR="192.168.0.0/16"
 


### PR DESCRIPTION
This change fixes the following error:
```
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 10.0.0.10
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly
```

```
On Linux, macOS and Solaris Oracle VM VirtualBox will only allow IP addresses in 192.168.56.0/21 range to be assigned to host-only adapters.
```