### PR TITLE
Fixed retrieving token

### DIFF
--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -86,7 +86,7 @@ subjects:
   namespace: kubernetes-dashboard
 EOF
 
-kubectl -n kubernetes-dashboard get secret "$(kubectl -n kubernetes-dashboard get admin-user default -o jsonpath="{.secrets[0].name}")" -o go-template="{{.data.token | base64decode}}" >> $config_path/token
+kubectl -n kubernetes-dashboard get secret/admin-user -o go-template="{{.data.token | base64decode}}" >> $config_path/token
 
 sudo -i -u vagrant bash << EOF
 whoami


### PR DESCRIPTION
Grabbing a service account secret with kubectl is as follows: `kubectl -n namespace get secret/user`. This should solve the no token during the master install.