### PR TITLE
Move configuration into a single location (settings.yaml)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,41 +1,73 @@
-NUM_WORKER_NODES=1
-IP_NW="10.0.0."
-IP_START=10
+
+require "yaml"
+settings = YAML.load_file "settings.yaml"
+
+IP_SECTIONS = settings["network"]["control_ip"].match(/^([0-9.]+\.)([^.]+)$/)
+# First 3 octets including the trailing dot:
+IP_NW = IP_SECTIONS.captures[0]
+# Last octet excluding all dots:
+IP_START = Integer(IP_SECTIONS.captures[1])
+NUM_WORKER_NODES = settings["nodes"]["workers"]["count"]
 
 Vagrant.configure("2") do |config|
-  config.vm.provision "shell", env: {"IP_NW" => IP_NW, "IP_START" => IP_START}, inline: <<-SHELL
+  config.vm.provision "shell", env: { "IP_NW" => IP_NW, "IP_START" => IP_START, "NUM_WORKER_NODES" => NUM_WORKER_NODES }, inline: <<-SHELL
       apt-get update -y
       echo "$IP_NW$((IP_START)) master-node" >> /etc/hosts
-      echo "$IP_NW$((IP_START+1)) worker-node01" >> /etc/hosts
-      echo "$IP_NW$((IP_START+2)) worker-node02" >> /etc/hosts
+      for i in `seq 1 ${NUM_WORKER_NODES}`; do
+        echo "$IP_NW$((IP_START+i)) worker-node0${i}" >> /etc/hosts
+      done
   SHELL
 
-  config.vm.box = "bento/ubuntu-22.04"
+  config.vm.box = settings["software"]["box"]
   config.vm.box_check_update = true
 
   config.vm.define "master" do |master|
     master.vm.hostname = "master-node"
-    master.vm.network "private_network", ip: IP_NW + "#{IP_START}"
+    master.vm.network "private_network", ip: settings["network"]["control_ip"]
     master.vm.provider "virtualbox" do |vb|
-        vb.memory = 4048
-        vb.cpus = 2
+        vb.cpus = settings["nodes"]["control"]["cpu"]
+        vb.memory = settings["nodes"]["control"]["memory"]
+        if settings["cluster_name"] and settings["cluster_name"] != ""
+          vb.customize ["modifyvm", :id, "--groups", ("/" + settings["cluster_name"])]
+        end
     end
-    master.vm.provision "shell", path: "scripts/common.sh"
-    master.vm.provision "shell", path: "scripts/master.sh"
+    master.vm.provision "shell",
+      env: {
+        "DNS_SERVERS" => settings["network"]["dns_servers"].join(" "),
+        "KUBERNETES_VERSION" => settings["software"]["kubernetes"],
+        "OS" => settings["software"]["os"]
+      },
+      path: "scripts/common.sh"
+    master.vm.provision "shell",
+      env: {
+        "CONTROL_IP" => settings["network"]["control_ip"],
+        "POD_CIDR" => settings["network"]["pod_cidr"],
+        "SERVICE_CIDR" => settings["network"]["service_cidr"]
+      },
+      path: "scripts/master.sh"
   end
 
   (1..NUM_WORKER_NODES).each do |i|
 
-  config.vm.define "node0#{i}" do |node|
-    node.vm.hostname = "worker-node0#{i}"
-    node.vm.network "private_network", ip: IP_NW + "#{IP_START + i}"
-    node.vm.provider "virtualbox" do |vb|
-        vb.memory = 2048
-        vb.cpus = 1
+    config.vm.define "node0#{i}" do |node|
+      node.vm.hostname = "worker-node0#{i}"
+      node.vm.network "private_network", ip: IP_NW + "#{IP_START + i}"
+      node.vm.provider "virtualbox" do |vb|
+          vb.cpus = settings["nodes"]["workers"]["cpu"]
+          vb.memory = settings["nodes"]["workers"]["memory"]
+          if settings["cluster_name"] and settings["cluster_name"] != ""
+            vb.customize ["modifyvm", :id, "--groups", ("/" + settings["cluster_name"])]
+          end
+      end
+      node.vm.provision "shell",
+        env: {
+          "DNS_SERVERS" => settings["network"]["dns_servers"].join(" "),
+          "KUBERNETES_VERSION" => settings["software"]["kubernetes"],
+          "OS" => settings["software"]["os"]
+        },
+        path: "scripts/common.sh"
+      node.vm.provision "shell", path: "scripts/node.sh"
     end
-    node.vm.provision "shell", path: "scripts/common.sh"
-    node.vm.provision "shell", path: "scripts/node.sh"
-  end
 
   end
 end 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -6,13 +6,11 @@ set -euxo pipefail
 
 # Variable Declaration
 
-KUBERNETES_VERSION="1.26.1-00"
-
 # DNS Setting
 sudo mkdir /etc/systemd/resolved.conf.d/
 cat <<EOF | sudo tee /etc/systemd/resolved.conf.d/dns_servers.conf
 [Resolve]
-DNS=8.8.8.8 1.1.1.1
+DNS=${DNS_SERVERS}
 EOF
 
 sudo systemctl restart systemd-resolved
@@ -20,14 +18,12 @@ sudo systemctl restart systemd-resolved
 # disable swap
 sudo swapoff -a
 
-# keeps the swaf off during reboot
+# keeps the swap off during reboot
 (crontab -l 2>/dev/null; echo "@reboot /sbin/swapoff -a") | crontab - || true
 sudo apt-get update -y
 # Install CRI-O Runtime
 
-OS="xUbuntu_20.04"
-
-VERSION="1.25"
+VERSION="$(echo ${KUBERNETES_VERSION} | grep -oE '[0-9]+\.[0-9]+')"
 
 # Create the .conf file to load the modules at bootup
 cat <<EOF | sudo tee /etc/modules-load.d/crio.conf

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -4,16 +4,13 @@
 
 set -euxo pipefail
 
-MASTER_IP="10.0.0.10"
 NODENAME=$(hostname -s)
-POD_CIDR="172.16.1.0/16"
-SERVICE_CIDR="172.17.1.0/18"
 
 sudo kubeadm config images pull
 
 echo "Preflight Check Passed: Downloaded All Required Images"
 
-sudo kubeadm init --apiserver-advertise-address=$MASTER_IP --apiserver-cert-extra-sans=$MASTER_IP --pod-network-cidr=$POD_CIDR --service-cidr=$SERVICE_CIDR --node-name "$NODENAME" --ignore-preflight-errors Swap
+sudo kubeadm init --apiserver-advertise-address=$CONTROL_IP --apiserver-cert-extra-sans=$CONTROL_IP --pod-network-cidr=$POD_CIDR --service-cidr=$SERVICE_CIDR --node-name "$NODENAME" --ignore-preflight-errors Swap
 
 mkdir -p "$HOME"/.kube
 sudo cp -i /etc/kubernetes/admin.conf "$HOME"/.kube/config

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,24 @@
+---
+# cluster_name is used to group the nodes in a folder within VirtualBox:
+cluster_name: Kubernetes Cluster
+# All IPs/CIDRs should be private and allowed in /etc/vbox/networks.conf.
+network:
+  # Worker IPs are simply incremented from the control IP.
+  control_ip: 10.0.0.10
+  dns_servers:
+    - 8.8.8.8
+    - 1.1.1.1
+  pod_cidr: 172.16.1.0/16
+  service_cidr: 172.17.1.0/18
+nodes:
+  control:
+    cpu: 2
+    memory: 4096
+  workers:
+    count: 1
+    cpu: 1
+    memory: 2048
+software:
+  box: bento/ubuntu-22.04
+  kubernetes: 1.26.1-00
+  os: xUbuntu_22.04


### PR DESCRIPTION
Thanks for the work you've done!

I've been using this project to spin up task/project-specific local dev clusters with different K8s versions, worker counts, CPU/memory, etc. This commit makes it easier for users to configure clusters as needed. The _cluster_name_ setting also groups the VMs for each cluster together within the VirtualBox GUI, so users can make copies of the repo, change the _cluster_name_, and spin up as many clusters as they want.