### PR TITLE
Install dashboard by default while making it easy to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,65 +58,30 @@ cp config ~/.kube/
 
 ## Install Kubernetes Dashboard
 
-Execute the following YAMLs to create the dashboard user.
+The dashboard is automatically installed by default, but it can be skipped by commenting out the dashboard version in _settings.yaml_ before running `vagrant up`.
 
-```
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: admin-user
-  namespace: kubernetes-dashboard
-EOF
+If you skip the dashboard installation, you can deploy it later by enabling it in _settings.yaml_ and running the following:
+```shell
+vagrant ssh -c "/vagrant/scripts/dashboard.sh" master
 ```
 
-```
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: admin-user
-  namespace: kubernetes-dashboard
-  annotations:
-    kubernetes.io/service-account.name: admin-user
-EOF
+## Kubernetes Dashboard Access
+
+To get the login token, copy it from _config/token_ or run the following command:
+```shell
+kubectl -n kubernetes-dashboard get secret/admin-user -o go-template="{{.data.token | base64decode}}"
 ```
 
-```
-cat <<EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: admin-user
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: admin-user
-  namespace: kubernetes-dashboard
-EOF
+Proxy the dashboard:
+```shell
+kubectl proxy
 ```
 
-Deploy the dashboard
-
-```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
-```
-
-use the following command to get the loging token
-
-```
-kubectl -n kubernetes-dashboard get secret/admin-user -o go-template="{{.data.token | base64decode}}" 
-```
-
-## Kubernetes Dashboard URL
-
+Open the site in your browser:
 ```shell
 http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/overview?namespace=kubernetes-dashboard
 ```
+
 ## To shutdown the cluster,
 
 ```shell

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,11 @@ Vagrant.configure("2") do |config|
         },
         path: "scripts/common.sh"
       node.vm.provision "shell", path: "scripts/node.sh"
+
+      # Only install the dashboard after provisioning the last worker (and when enabled).
+      if i == NUM_WORKER_NODES and settings["software"]["dashboard"] and settings["software"]["dashboard"] != ""
+        node.vm.provision "shell", path: "scripts/dashboard.sh"
+      end
     end
 
   end

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Deploys the Kubernetes dashboard when enabled in settings.yaml
+
+set -euxo pipefail
+
+config_path="/vagrant/configs"
+
+DASHBOARD_VERSION=$(grep -E '^\s*dashboard:' /vagrant/settings.yaml | sed -E 's/[^:]+: *//')
+if [ -n "${DASHBOARD_VERSION}" ]; then
+  while sudo -i -u vagrant kubectl get pods -A -l k8s-app=metrics-server | awk 'split($3, a, "/") && a[1] != a[2] { print $0; }' | grep -v "RESTARTS"; do
+    echo 'Waiting for metrics server to be ready...'
+    sleep 5
+  done
+  echo 'Metrics server is ready. Installing dashboard...'
+
+  sudo -i -u vagrant kubectl create namespace kubernetes-dashboard
+
+  echo "Creating the dashboard user..."
+
+  cat <<EOF | sudo -i -u vagrant kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+EOF
+
+  cat <<EOF | sudo -i -u vagrant kubectl apply -f -
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: admin-user
+EOF
+
+  cat <<EOF | sudo -i -u vagrant kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard
+EOF
+
+  echo "Deploying the dashboard..."
+  sudo -i -u vagrant kubectl apply -f "https://raw.githubusercontent.com/kubernetes/dashboard/v${DASHBOARD_VERSION}/aio/deploy/recommended.yaml"
+
+  sudo -i -u vagrant kubectl -n kubernetes-dashboard get secret/admin-user -o go-template="{{.data.token | base64decode}}" >> "${config_path}/token"
+  echo "The following token was also saved to: configs/token"
+  cat "${config_path}/token"
+  echo "
+Use it to log in at:
+http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/overview?namespace=kubernetes-dashboard
+"
+fi

--- a/settings.yaml
+++ b/settings.yaml
@@ -20,5 +20,7 @@ nodes:
     memory: 2048
 software:
   box: bento/ubuntu-22.04
+  # To skip the dashboard installation, set its version to an empty value or comment it out:
+  dashboard: 2.7.0
   kubernetes: 1.26.1-00
   os: xUbuntu_22.04


### PR DESCRIPTION
I started this change by moving the dashboard version into the config and installing it during provisioning. However, after doing that, I saw the issue with the dashboard not coming up as you mentioned in #32. I suspected a timing issue since it had worked for me previously when I stepped away for a while and then installed it manually.

It seems that the dashboard depends on the metrics scraper, which depends on the metrics server. The fix I implemented is to wait for the metrics server to be ready before installing the dashboard. Please test the change a few times yourself before merging in case it needs an additional wait period.