### PR TITLE
Creating  /etc/systemd/resolved.conf.d/ only if it doesn't exist

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -7,7 +7,9 @@ set -euxo pipefail
 # Variable Declaration
 
 # DNS Setting
-sudo mkdir /etc/systemd/resolved.conf.d/
+if [ ! -d /etc/systemd/resolved.conf.d ]; then
+	sudo mkdir /etc/systemd/resolved.conf.d/
+fi
 cat <<EOF | sudo tee /etc/systemd/resolved.conf.d/dns_servers.conf
 [Resolve]
 DNS=${DNS_SERVERS}


### PR DESCRIPTION
Adding if condition to create this directory if it doesn't already exist. provisoning was failing because the directory existed.