### PR TITLE
added arm 64 architecture (for Apple M1 usage)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
       done
   SHELL
 
-  if RbConfig::CONFIG['host_cpu'] =~ /aarch64/
+  if `uname -m`.strip == "aarch64"
     config.vm.box = settings["software"]["box"] + "-arm64"
   else
     config.vm.box = settings["software"]["box"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,11 @@ Vagrant.configure("2") do |config|
       done
   SHELL
 
-  config.vm.box = settings["software"]["box"]
+  if RbConfig::CONFIG['host_cpu'] =~ /aarch64/
+    config.vm.box = settings["software"]["box"] + "-arm64"
+  else
+    config.vm.box = settings["software"]["box"]
+  end
   config.vm.box_check_update = true
 
   config.vm.define "master" do |master|


### PR DESCRIPTION
If the architecture of the host is aarch64, add arm64 to the end of the box, so that it will work on an Apple M1 Mac as well as every where else it runs.