### PR TITLE
fix: Update kubenetes apt key according to latest documentation

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,9 +68,12 @@ echo "CRI runtime installed susccessfully"
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo 
+gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] 
+https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee 
+/etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"
 sudo apt-get update -y


### PR DESCRIPTION
I'm getting this error when I tried to run the Vagrant scripts:
```bash
    master: Get:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease [8,993 B]
    master: Err:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
    master:   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    master: Reading package lists...
    master: W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    master: E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

According to https://github.com/kubernetes/website/pull/41307 , this PR is updated using the latest method.

Related issue:
- Resolve #45 
- Resolve #39 
- Resolve #47