### PR TITLE
Fix kubernetes apt commands

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,12 +68,9 @@ echo "CRI runtime installed susccessfully"
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo 
-gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] 
-https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee 
-/etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"
 sudo apt-get update -y


### PR DESCRIPTION
Close #48 

Fix https://github.com/techiescamp/vagrant-kubeadm-kubernetes/commit/8c8ba0d6ac8000880a07260895d8622bfcaf35ec#commitcomment-116617605

I have no idea why somehow it end up like that, I wasn't intended to do so, since I remember I directly copied the commands from https://github.com/kubernetes/website/pull/41307 without doing anything else, sorry!