### PR TITLE
Patch update for public key is not available NON avaialble Error

### DIFF
--- a/mysql-deployment.yml
+++ b/mysql-deployment.yml
@@ -1,0 +1,129 @@
+apiVersion: v1
+
+kind: Service
+
+metadata:
+
+  name: wordpress-mysql
+
+  labels:
+
+    app: wordpress
+
+spec:
+
+  ports:
+
+    - port: 3306
+
+  selector:
+
+    app: wordpress
+
+    tier: mysql
+
+  clusterIP: None
+
+---
+
+apiVersion: v1
+
+kind: PersistentVolumeClaim
+
+metadata:
+
+  name: mysql-pv-claim
+
+  labels:
+
+    app: wordpress
+
+spec:
+
+  accessModes:
+
+    - ReadWriteOnce
+
+  resources:
+
+    requests:
+
+      storage: 20Gi
+
+---
+
+apiVersion: apps/v1
+
+kind: Deployment
+
+metadata:
+
+  name: wordpress-mysql
+
+  labels:
+
+    app: wordpress
+
+spec:
+
+  selector:
+
+    matchLabels:
+
+      app: wordpress
+
+      tier: mysql
+
+  strategy:
+
+    type: Recreate
+
+  template:
+
+    metadata:
+
+      labels:
+
+        app: wordpress
+
+        tier: mysql
+
+    spec:
+
+      containers:
+
+      - image: mysql:5.6
+
+        name: mysql
+
+        env:
+
+        - name: MYSQL_ROOT_PASSWORD
+
+          valueFrom:
+
+            secretKeyRef:
+
+              name: mysql-pass
+
+              key: password
+
+        ports:
+
+        - containerPort: 3306
+
+          name: mysql
+
+        volumeMounts:
+
+        - name: mysql-persistent-storage
+
+          mountPath: /var/lib/mysql
+
+      volumes:
+
+      - name: mysql-persistent-storage
+
+        persistentVolumeClaim:
+
+          claimName: mysql-pv-claim

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -66,11 +66,15 @@ sudo systemctl enable crio --now
 
 echo "CRI runtime installed susccessfully"
 
-sudo apt-get update
+sudo apt-get update -y
 sudo apt-get install -y apt-transport-https ca-certificates curl
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+sudo curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+#sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+#echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"
 sudo apt-get update -y


### PR DESCRIPTION
While Using the code configuration to build Kubernetes using Vagrant - I have observed this error

`    master: No VM guests are running outdated hypervisor (qemu) binaries on this host.
    master: + sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
    master: + echo 'deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main'
    master: + sudo tee /etc/apt/sources.list.d/kubernetes.list
    master: deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main
    master: + sudo apt-get update -y
    master: Get:1 http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26/xUbuntu_22.04  InRelease [1,632 B]
    master: Get:2 https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04  InRelease [1,639 B]
    master: Hit:3 http://us.archive.ubuntu.com/ubuntu jammy InRelease
    master: Hit:5 http://us.archive.ubuntu.com/ubuntu jammy-updates InRelease
    master: Get:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease [8,993 B]
    master: Hit:6 http://us.archive.ubuntu.com/ubuntu jammy-backports InRelease
    master: Err:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
    master:   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    master: Hit:7 http://us.archive.ubuntu.com/ubuntu jammy-security InRelease
    master: Reading package lists...
    master: W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    master: E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.`

The Fix is the Following:

`    Update the apt package index and install packages needed to use the Kubernetes apt repository:

    sudo apt-get update
    sudo apt-get install -y ca-certificates curl

    If you use Debian 9 (stretch) or earlier you would also need to install apt-transport-https:

    sudo apt-get install -y apt-transport-https

    Download the Google Cloud public signing key:

    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg

    Add the Kubernetes apt repository:

    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list

    Update apt package index with the new repository and install kubectl:

    sudo apt-get update
    sudo apt-get install -y kubectl
`

So that's what I did and it worked. On my end.