### PR TITLE
Fix Issue #44: remove extra return (\r) from `/vagrant/settings.yam'

### DIFF
--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 config_path="/vagrant/configs"
 
-DASHBOARD_VERSION=$(grep -E '^\s*dashboard:' /vagrant/settings.yaml | sed -E 's/[^:]+: *//')
+DASHBOARD_VERSION=$(grep -E '^\s*dashboard:' /vagrant/settings.yaml | sed -E -e 's/[^:]+: *//' -e 's/\r$//')
 if [ -n "${DASHBOARD_VERSION}" ]; then
   while sudo -i -u vagrant kubectl get pods -A -l k8s-app=metrics-server | awk 'split($3, a, "/") && a[1] != a[2] { print $0; }' | grep -v "RESTARTS"; do
     echo 'Waiting for metrics server to be ready...'


### PR DESCRIPTION
The dashboard version to download is taken, in the running VM, from file `/vagrant/settings.yaml`.
As long as it might be encoded as DOS file it might include extra carriage returns (\r). We simply remove them.