### PR TITLE
Update configs/scripts to latest k8s v1.28

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -70,7 +70,7 @@ sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"
 sudo apt-get update -y

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,5 +34,5 @@ software:
   calico: 3.26.0
   # To skip the dashboard installation, set its version to an empty value or comment it out:
   dashboard: 2.7.0
-  kubernetes: 1.27.1-00
+  kubernetes: 1.28.2-00
   os: xUbuntu_22.04


### PR DESCRIPTION
- Changed kubernetes-archive-keyring.gpg URL for installing kubectl
- Update default k8s to 1.28 to match the current versions for the certificates