### PR TITLE
fix: update the script to fix kubernetes-xenial not signed error during bootstrapping 

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,9 +68,9 @@ echo "CRI runtime installed successfully"
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null
 
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"
 sudo apt-get update -y


### PR DESCRIPTION
## The problem
While running `vagrant up` for the first time, `common.sh` gives this error: 

```
...
    node01: Hit:1 http://us.archive.ubuntu.com/ubuntu jammy InRelease
    node01: Hit:2 http://us.archive.ubuntu.com/ubuntu jammy-updates InRelease
    node01: Hit:3 http://us.archive.ubuntu.com/ubuntu jammy-backports InRelease
    node01: Hit:4 http://us.archive.ubuntu.com/ubuntu jammy-security InRelease
    node01: Get:6 http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.28/xUbuntu_22.04  InRelease [1,632 B]
    node01: Get:7 https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04  InRelease [1,639 B]
    node01: Get:5 https://packages.cloud.google.com/apt kubernetes-xenial InRelease [8,993 B]
    node01: Err:5 https://packages.cloud.google.com/apt kubernetes-xenial InRelease
    node01:   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    node01: Reading package lists...
    node01: W: GPG error: https://packages.cloud.google.com/apt kubernetes-xenial InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B53DC80D13EDEF05
    node01: E: The repository 'https://apt.kubernetes.io kubernetes-xenial InRelease' is not signed.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

Based on the solution here: https://github.com/kubernetes/release/issues/2862

I am proposing the changes in this PR

### Environment (bare metal)
Hardware: IBM System x M2 x3650
CPU: Intel(R) Xeon(R) CPU  X5570  @ 2.93GHz
Memory: 96GB DDR 3 @ 800 MHz
OS:  Ubuntu 20.04.6 LTS
Virtualization Provider: Virtualbox 7

### What changed
Update `common.sh` with the correct pgp key and key location for import.

### How I tested
```
vagrant destroy
vagrant up
```
To verify the changes work

### Regression test
Unknown, not performed.