### PR TITLE
Allow running vagrant from any subdir of the project.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 
 require "yaml"
-settings = YAML.load_file "settings.yaml"
+vagrant_root = File.dirname(File.expand_path(__FILE__))
+settings = YAML.load_file "#{vagrant_root}/settings.yaml"
 
 IP_SECTIONS = settings["network"]["control_ip"].match(/^([0-9.]+\.)([^.]+)$/)
 # First 3 octets including the trailing dot:


### PR DESCRIPTION
Currently, vagrant commands fail from any subdirectory in the project. This change always loads settings.yaml from the project root, which resolves the issue.