### PR TITLE
fix: update apt source

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure("2") do |config|
           "DNS_SERVERS" => settings["network"]["dns_servers"].join(" "),
           "ENVIRONMENT" => settings["environment"],
           "KUBERNETES_VERSION" => settings["software"]["kubernetes"],
+          "KUBERNETES_VERSION_SHORT" => settings["software"]["kubernetes"][0..3],
           "OS" => settings["software"]["os"]
         },
         path: "scripts/common.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure("2") do |config|
         "DNS_SERVERS" => settings["network"]["dns_servers"].join(" "),
         "ENVIRONMENT" => settings["environment"],
         "KUBERNETES_VERSION" => settings["software"]["kubernetes"],
+        "KUBERNETES_VERSION_SHORT" => settings["software"]["kubernetes"][0..3],
         "OS" => settings["software"]["os"]
       },
       path: "scripts/common.sh"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,8 +68,9 @@ echo "CRI runtime installed successfully"
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/kubernetes-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null
+sudo mkdir /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION_SHORT/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION_SHORT/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update -y
 sudo apt-get install -y kubelet="$KUBERNETES_VERSION" kubectl="$KUBERNETES_VERSION" kubeadm="$KUBERNETES_VERSION"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -68,7 +68,7 @@ echo "CRI runtime installed successfully"
 
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
-sudo mkdir /etc/apt/keyrings
+sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION_SHORT/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$KUBERNETES_VERSION_SHORT/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,5 +34,5 @@ software:
   calico: 3.26.0
   # To skip the dashboard installation, set its version to an empty value or comment it out:
   dashboard: 2.7.0
-  kubernetes: 1.28.2-00
+  kubernetes: 1.28.2-*
   os: xUbuntu_22.04


### PR DESCRIPTION
Hi! 

I was testing your scripts and found an issue with the APT source, which was recently changed.

I propose to follow the [upstream documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management) and add a new variable that sets the `KUBERNETES_SHORT_VERSION` to adapt to the upcoming releases.

I hope this helps!